### PR TITLE
Add Comment and Hobbies entities to the database

### DIFF
--- a/Scalefocus HobbyAPI Database/Data/ScalefocusDbContext.cs
+++ b/Scalefocus HobbyAPI Database/Data/ScalefocusDbContext.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.EntityFrameworkCore;
+﻿
+using Microsoft.EntityFrameworkCore;
 using Scalefocus_HobbyAPI_Database.Models;
 
 namespace Scalefocus_HobbyAPI_Database.Data
@@ -10,6 +11,8 @@ namespace Scalefocus_HobbyAPI_Database.Data
         public DbSet<User> Users { get; set; }
 
         public DbSet<Hobbies> Hobbies { get; set; }
+
+        public DbSet<CommentEntity> Comments { get; set; }
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
@@ -25,6 +28,10 @@ namespace Scalefocus_HobbyAPI_Database.Data
 
             modelBuilder.Entity<User>()
                 .HasKey(e => e.Id);
+            modelBuilder.Entity<Hobbies>()
+                .HasKey(h => h.Id);
+            modelBuilder.Entity<CommentEntity>()
+                .HasKey(c => c.Id);
 
             // Event.OwnerId references User.Id (Owner relationship)
             modelBuilder.Entity<Event>()
@@ -55,20 +62,20 @@ namespace Scalefocus_HobbyAPI_Database.Data
                 new User
                 {
                     Id = user1Id,
+                    Username = "alice123",
                     FirstName = "Alice",
                     LastName = "Smith",
                     Email = "alice.smith@example.com",
-                    PasswordHash = "hash1",
-                    PasswordSalt = "salt1"
+                    PasswordHash = "hash1"
                 },
                 new User
                 {
                     Id = user2Id,
+                    Username = "bob456",
                     FirstName = "Bob",
                     LastName = "Johnson",
                     Email = "bob.johnson@example.com",
-                    PasswordHash = "hash2",
-                    PasswordSalt = "salt2"
+                    PasswordHash = "hash2"
                 }
             );
 
@@ -107,6 +114,50 @@ namespace Scalefocus_HobbyAPI_Database.Data
                     ModifiedAt = (DateTime?)null,
                     ModifiedBy = (Guid?)null,
                     Status = EventStatus.Scheduled
+                }
+            );
+            // Seed Hobbies
+            modelBuilder.Entity<Hobbies>().HasData(
+                new Hobbies
+                {
+                    Id = 1,
+                    Title = "Chess",
+                    Date = new DateTime(2024, 1, 1),
+                    Updated_at = 20240101
+                },
+                new Hobbies
+                {
+                    Id = 2,
+                    Title = "Painting",
+                    Date = new DateTime(2024, 2, 1),
+                    Updated_at = 20240201
+                }
+            );
+            // Seed Comments
+            modelBuilder.Entity<CommentEntity>().HasData(
+                new
+                {
+                    Id = 1,
+                    EventId = 1,
+                    UserId = user1Id,
+                    Content = "Looking forward to this event!",
+                    CreatedAt = new DateTime(2024, 6, 2, 10, 0, 0)
+                },
+                new
+                {
+                    Id = 2,
+                    EventId = 1,
+                    UserId = user2Id,
+                    Content = "Count me in!",
+                    CreatedAt = new DateTime(2024, 6, 3, 11, 0, 0)
+                },
+                new
+                {
+                    Id = 3,
+                    EventId = 2,
+                    UserId = user2Id,
+                    Content = "Excited to learn painting.",
+                    CreatedAt = new DateTime(2024, 7, 12, 12, 0, 0)
                 }
             );
         }

--- a/Scalefocus HobbyAPI Database/Migrations/20250730140953_Initial.Designer.cs
+++ b/Scalefocus HobbyAPI Database/Migrations/20250730140953_Initial.Designer.cs
@@ -12,7 +12,7 @@ using Scalefocus_HobbyAPI_Database.Data;
 namespace Scalefocus_HobbyAPI_Database.Migrations
 {
     [DbContext(typeof(ScalefocusDbContext))]
-    [Migration("20250730064824_Initial")]
+    [Migration("20250730140953_Initial")]
     partial class Initial
     {
         /// <inheritdoc />
@@ -24,6 +24,61 @@ namespace Scalefocus_HobbyAPI_Database.Migrations
                 .HasAnnotation("Relational:MaxIdentifierLength", 128);
 
             SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
+
+            modelBuilder.Entity("Scalefocus_HobbyAPI_Database.Models.CommentEntity", b =>
+                {
+                    b.Property<int>("ID")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("int");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("ID"));
+
+                    b.Property<string>("Content")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<DateTime>("CreatedAt")
+                        .HasColumnType("datetime2");
+
+                    b.Property<int>("EventID")
+                        .HasColumnType("int");
+
+                    b.Property<DateTime?>("UpdatedAt")
+                        .HasColumnType("datetime2");
+
+                    b.Property<Guid>("UserID")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.HasKey("ID");
+
+                    b.ToTable("Comments");
+
+                    b.HasData(
+                        new
+                        {
+                            ID = 1,
+                            Content = "Looking forward to this event!",
+                            CreatedAt = new DateTime(2024, 6, 2, 10, 0, 0, 0, DateTimeKind.Unspecified),
+                            EventID = 1,
+                            UserID = new Guid("3bae1d94-7392-477e-922e-e656a8597661")
+                        },
+                        new
+                        {
+                            ID = 2,
+                            Content = "Count me in!",
+                            CreatedAt = new DateTime(2024, 6, 3, 11, 0, 0, 0, DateTimeKind.Unspecified),
+                            EventID = 1,
+                            UserID = new Guid("7e61f925-b7d6-4e69-bbc2-a6695e2e424f")
+                        },
+                        new
+                        {
+                            ID = 3,
+                            Content = "Excited to learn painting.",
+                            CreatedAt = new DateTime(2024, 7, 12, 12, 0, 0, 0, DateTimeKind.Unspecified),
+                            EventID = 2,
+                            UserID = new Guid("7e61f925-b7d6-4e69-bbc2-a6695e2e424f")
+                        });
+                });
 
             modelBuilder.Entity("Scalefocus_HobbyAPI_Database.Models.Event", b =>
                 {
@@ -121,6 +176,45 @@ namespace Scalefocus_HobbyAPI_Database.Migrations
                         });
                 });
 
+            modelBuilder.Entity("Scalefocus_HobbyAPI_Database.Models.Hobbies", b =>
+                {
+                    b.Property<int>("type_id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("int");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("type_id"));
+
+                    b.Property<DateTime>("date")
+                        .HasColumnType("datetime2");
+
+                    b.Property<string>("title")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<int>("updated_at")
+                        .HasColumnType("int");
+
+                    b.HasKey("type_id");
+
+                    b.ToTable("Hobbies");
+
+                    b.HasData(
+                        new
+                        {
+                            type_id = 1,
+                            date = new DateTime(2024, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                            title = "Chess",
+                            updated_at = 20240101
+                        },
+                        new
+                        {
+                            type_id = 2,
+                            date = new DateTime(2024, 2, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                            title = "Painting",
+                            updated_at = 20240201
+                        });
+                });
+
             modelBuilder.Entity("Scalefocus_HobbyAPI_Database.Models.User", b =>
                 {
                     b.Property<Guid>("Id")
@@ -143,7 +237,7 @@ namespace Scalefocus_HobbyAPI_Database.Migrations
                         .IsRequired()
                         .HasColumnType("nvarchar(max)");
 
-                    b.Property<string>("PasswordSalt")
+                    b.Property<string>("Username")
                         .IsRequired()
                         .HasColumnType("nvarchar(max)");
 
@@ -159,7 +253,7 @@ namespace Scalefocus_HobbyAPI_Database.Migrations
                             FirstName = "Alice",
                             LastName = "Smith",
                             PasswordHash = "hash1",
-                            PasswordSalt = "salt1"
+                            Username = "alice123"
                         },
                         new
                         {
@@ -168,7 +262,7 @@ namespace Scalefocus_HobbyAPI_Database.Migrations
                             FirstName = "Bob",
                             LastName = "Johnson",
                             PasswordHash = "hash2",
-                            PasswordSalt = "salt2"
+                            Username = "bob456"
                         });
                 });
 

--- a/Scalefocus HobbyAPI Database/Migrations/20250730140953_Initial.cs
+++ b/Scalefocus HobbyAPI Database/Migrations/20250730140953_Initial.cs
@@ -14,15 +14,47 @@ namespace Scalefocus_HobbyAPI_Database.Migrations
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.CreateTable(
+                name: "Comments",
+                columns: table => new
+                {
+                    ID = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Content = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    UserID = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    EventID = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Comments", x => x.ID);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Hobbies",
+                columns: table => new
+                {
+                    type_id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    title = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    date = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    updated_at = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Hobbies", x => x.type_id);
+                });
+
+            migrationBuilder.CreateTable(
                 name: "Users",
                 columns: table => new
                 {
                     Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Username = table.Column<string>(type: "nvarchar(max)", nullable: false),
                     FirstName = table.Column<string>(type: "nvarchar(max)", nullable: false),
                     LastName = table.Column<string>(type: "nvarchar(max)", nullable: false),
                     Email = table.Column<string>(type: "nvarchar(max)", nullable: false),
-                    PasswordHash = table.Column<string>(type: "nvarchar(max)", nullable: false),
-                    PasswordSalt = table.Column<string>(type: "nvarchar(max)", nullable: false)
+                    PasswordHash = table.Column<string>(type: "nvarchar(max)", nullable: false)
                 },
                 constraints: table =>
                 {
@@ -74,12 +106,31 @@ namespace Scalefocus_HobbyAPI_Database.Migrations
                 });
 
             migrationBuilder.InsertData(
-                table: "Users",
-                columns: new[] { "Id", "Email", "FirstName", "LastName", "PasswordHash", "PasswordSalt" },
+                table: "Comments",
+                columns: new[] { "ID", "Content", "CreatedAt", "EventID", "UpdatedAt", "UserID" },
                 values: new object[,]
                 {
-                    { new Guid("3bae1d94-7392-477e-922e-e656a8597661"), "alice.smith@example.com", "Alice", "Smith", "hash1", "salt1" },
-                    { new Guid("7e61f925-b7d6-4e69-bbc2-a6695e2e424f"), "bob.johnson@example.com", "Bob", "Johnson", "hash2", "salt2" }
+                    { 1, "Looking forward to this event!", new DateTime(2024, 6, 2, 10, 0, 0, 0, DateTimeKind.Unspecified), 1, null, new Guid("3bae1d94-7392-477e-922e-e656a8597661") },
+                    { 2, "Count me in!", new DateTime(2024, 6, 3, 11, 0, 0, 0, DateTimeKind.Unspecified), 1, null, new Guid("7e61f925-b7d6-4e69-bbc2-a6695e2e424f") },
+                    { 3, "Excited to learn painting.", new DateTime(2024, 7, 12, 12, 0, 0, 0, DateTimeKind.Unspecified), 2, null, new Guid("7e61f925-b7d6-4e69-bbc2-a6695e2e424f") }
+                });
+
+            migrationBuilder.InsertData(
+                table: "Hobbies",
+                columns: new[] { "type_id", "date", "title", "updated_at" },
+                values: new object[,]
+                {
+                    { 1, new DateTime(2024, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), "Chess", 20240101 },
+                    { 2, new DateTime(2024, 2, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), "Painting", 20240201 }
+                });
+
+            migrationBuilder.InsertData(
+                table: "Users",
+                columns: new[] { "Id", "Email", "FirstName", "LastName", "PasswordHash", "Username" },
+                values: new object[,]
+                {
+                    { new Guid("3bae1d94-7392-477e-922e-e656a8597661"), "alice.smith@example.com", "Alice", "Smith", "hash1", "alice123" },
+                    { new Guid("7e61f925-b7d6-4e69-bbc2-a6695e2e424f"), "bob.johnson@example.com", "Bob", "Johnson", "hash2", "bob456" }
                 });
 
             migrationBuilder.InsertData(
@@ -111,7 +162,13 @@ namespace Scalefocus_HobbyAPI_Database.Migrations
         protected override void Down(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.DropTable(
+                name: "Comments");
+
+            migrationBuilder.DropTable(
                 name: "Events");
+
+            migrationBuilder.DropTable(
+                name: "Hobbies");
 
             migrationBuilder.DropTable(
                 name: "Users");

--- a/Scalefocus HobbyAPI Database/Migrations/20250730141721_Changed_Entity_Properties.Designer.cs
+++ b/Scalefocus HobbyAPI Database/Migrations/20250730141721_Changed_Entity_Properties.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Scalefocus_HobbyAPI_Database.Data;
 
@@ -11,9 +12,11 @@ using Scalefocus_HobbyAPI_Database.Data;
 namespace Scalefocus_HobbyAPI_Database.Migrations
 {
     [DbContext(typeof(ScalefocusDbContext))]
-    partial class ScalefocusDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250730141721_Changed_Entity_Properties")]
+    partial class Changed_Entity_Properties
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Scalefocus HobbyAPI Database/Migrations/20250730141721_Changed_Entity_Properties.cs
+++ b/Scalefocus HobbyAPI Database/Migrations/20250730141721_Changed_Entity_Properties.cs
@@ -1,0 +1,88 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Scalefocus_HobbyAPI_Database.Migrations
+{
+    /// <inheritdoc />
+    public partial class Changed_Entity_Properties : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "updated_at",
+                table: "Hobbies",
+                newName: "Updated_at");
+
+            migrationBuilder.RenameColumn(
+                name: "title",
+                table: "Hobbies",
+                newName: "Title");
+
+            migrationBuilder.RenameColumn(
+                name: "date",
+                table: "Hobbies",
+                newName: "Date");
+
+            migrationBuilder.RenameColumn(
+                name: "type_id",
+                table: "Hobbies",
+                newName: "Id");
+
+            migrationBuilder.RenameColumn(
+                name: "UserID",
+                table: "Comments",
+                newName: "UserId");
+
+            migrationBuilder.RenameColumn(
+                name: "EventID",
+                table: "Comments",
+                newName: "EventId");
+
+            migrationBuilder.RenameColumn(
+                name: "ID",
+                table: "Comments",
+                newName: "Id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "Updated_at",
+                table: "Hobbies",
+                newName: "updated_at");
+
+            migrationBuilder.RenameColumn(
+                name: "Title",
+                table: "Hobbies",
+                newName: "title");
+
+            migrationBuilder.RenameColumn(
+                name: "Date",
+                table: "Hobbies",
+                newName: "date");
+
+            migrationBuilder.RenameColumn(
+                name: "Id",
+                table: "Hobbies",
+                newName: "type_id");
+
+            migrationBuilder.RenameColumn(
+                name: "UserId",
+                table: "Comments",
+                newName: "UserID");
+
+            migrationBuilder.RenameColumn(
+                name: "EventId",
+                table: "Comments",
+                newName: "EventID");
+
+            migrationBuilder.RenameColumn(
+                name: "Id",
+                table: "Comments",
+                newName: "ID");
+        }
+    }
+}

--- a/Scalefocus HobbyAPI Database/Models/CommentEntity.cs
+++ b/Scalefocus HobbyAPI Database/Models/CommentEntity.cs
@@ -2,20 +2,20 @@
 using Microsoft.EntityFrameworkCore;
 using System.ComponentModel.DataAnnotations;
 
-namespace CommentAPI.Entities
+namespace Scalefocus_HobbyAPI_Database.Models
 {
     public class CommentEntity
     {
         [Key]
-        public Guid ID { get; set; }
+        public int Id { get; set; }
         [Required]
-        public string Content { get; set; }
+        public string Content { get; set; } = string.Empty;
         [Required]
         public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
         public DateTime? UpdatedAt { get; set; }  
         [Required]
-        public Guid UserID { get; set; }
+        public Guid UserId { get; set; }
         [Required]
-        public Guid EventID { get; set; }
+        public int EventId { get; set; }
     }
 }

--- a/Scalefocus HobbyAPI Database/Models/Hobbies.cs
+++ b/Scalefocus HobbyAPI Database/Models/Hobbies.cs
@@ -6,12 +6,12 @@ namespace Scalefocus_HobbyAPI_Database.Models
     {
         [Key]
         [Required]
-        public int type_id { get; set; }
+        public int Id { get; set; }
         [Required]
-        public string title { get; set; }
+        public string Title { get; set; } = string.Empty;
         [Required]
-        public DateTime date { get; set; }
+        public DateTime Date { get; set; }
         [Required]
-        public int updated_at { get; set; }
+        public int Updated_at { get; set; }
     }
 }

--- a/Scalefocus HobbyAPI Database/Models/User.cs
+++ b/Scalefocus HobbyAPI Database/Models/User.cs
@@ -8,17 +8,17 @@ namespace Scalefocus_HobbyAPI_Database.Models
         public Guid Id { get; set; }
 
         [Required]
-        public string Username { get; set; }
+        public string Username { get; set; } = string.Empty;
 
         [Required]
-        public string FirstName { get; set; }
+        public string FirstName { get; set; } = string.Empty;
 
         [Required]
-        public string LastName { get; set; }
+        public string LastName { get; set; } = string.Empty;
 
         [Required]
-        public string Email { get; set; }
+        public string Email { get; set; } = string.Empty;
 
-        public string PasswordHash { get; set; }
+        public string PasswordHash { get; set; } = string.Empty;
     }
 }


### PR DESCRIPTION
Updated ScalefocusDbContext to include DbSet<CommentEntity> and Hobbies. Introduced seeding for both entities. Modified migration files to reflect new tables and properties. Renamed properties in CommentEntity and Hobbies to follow C# conventions. Added Username property to User. Created new migration files for schema changes.